### PR TITLE
Fix Meetup Twitter-Link in Liste

### DIFF
--- a/resources/views/columns/meetups/action.blade.php
+++ b/resources/views/columns/meetups/action.blade.php
@@ -74,7 +74,7 @@
                 xs
                 black
                 target="_blank"
-                :href="$row->twitter_username"
+                :href="'https://twitter.com/'.$row->twitter_username"
             >
                 <i class="fa fa-brand fa-twitter mr-2"></i>
                 {{ __('Twitter') }}


### PR DESCRIPTION
Beim Meetup soll man den Twitter-Handle eintragen, der öffentliche Link verweist dann jedoch nicht auf Twitter, sondern nur auf das Handle, so dass URLs wie `https://portal.einundzwanzig.space/de/meetup/Einundzwanzig_N` zustande kommen.

Hiermit gefixt.